### PR TITLE
49 implement tournament seed generator

### DIFF
--- a/.cursor/skills/write-pr-description/SKILL.md
+++ b/.cursor/skills/write-pr-description/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: write-pr-description
+description: >-
+  Draft pull request titles and descriptions by comparing the current branch to
+  the repo default branch. Use when the user asks for a PR description, PR body,
+  pull request summary, or help opening a PR without creating one yet.
+---
+
+# Write PR Description
+
+Draft a PR title and description from real branch diffs. Do not create or push the PR unless the user explicitly asks.
+
+## 1. Resolve the default branch
+
+Use the first method that works:
+
+```bash
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+git symbolic-ref refs/remotes/origin/HEAD --short
+```
+
+Strip a leading `origin/` from the result. Fall back to `main`, then `master`.
+
+Set `BASE` to that branch name.
+
+## 2. Gather changes
+
+Run these in parallel (replace `BASE`):
+
+```bash
+git status
+git branch --show-current
+git log --oneline BASE...HEAD
+git diff --stat BASE...HEAD
+git diff BASE...HEAD
+```
+
+If `BASE...HEAD` is empty but the working tree is dirty, the branch may not be ahead of default yet — also run `git diff` and `git diff --cached` and include uncommitted work in the summary.
+
+If the current branch **is** the default branch, describe uncommitted and staged changes against `HEAD` instead.
+
+## 3. Read the PR template
+
+If present, read `.github/pull_request_template.md` (or `.github/PULL_REQUEST_TEMPLATE.md`) and match its sections. If none exists, use:
+
+```markdown
+## Summary
+
+## Test plan
+
+- [ ] Tested locally
+```
+
+## 4. Analyze the diff
+
+Review **all** commits in `BASE...HEAD`, not only the latest. From the diff, identify:
+
+- What changed and why (user-facing outcome, not a file list)
+- API, schema, or config changes worth calling out
+- Migrations or manual setup steps
+- Risky areas or edge cases
+
+Keep prose proportional to change size. A small fix gets a short summary; a multi-area feature gets a few focused bullets.
+
+## 5. Write the output
+
+Return:
+
+1. **Suggested title** — imperative, under ~72 characters, focused on the main outcome
+2. **PR description** — filled template in a single fenced markdown block, ready to paste into GitHub
+
+Title and summary should reflect the full branch diff. Do not list every changed file unless the user asked for a changelog-style breakdown.
+
+### Test plan guidance
+
+- Check off "Tested locally" only when the user confirmed testing or the conversation makes it clear
+- Add specific checks only when the diff warrants them (new endpoints, UI flows, migrations, etc.)
+- Leave the checkbox unchecked with concrete suggested checks when testing was not discussed
+
+## 6. Optional: open the PR
+
+Only if the user explicitly asks to create the PR:
+
+```bash
+git push -u origin HEAD
+gh pr create --title "TITLE" --body "$(cat <<'EOF'
+BODY HERE
+EOF
+)"
+```
+
+Return the PR URL when created.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Test plan
+
+- [ ] Tested locally
+
+<!-- Add any specific checks if relevant -->

--- a/api/app.js
+++ b/api/app.js
@@ -14,6 +14,7 @@ const songRoutes = require('./routes/song');
 const startGgImportRoutes = require('./routes/startGgImport');
 const startGgPublicRoutes = require('./routes/startGgPublic');
 const browseRoutes = require('./routes/browse');
+const seedRoutes = require('./routes/seed');
 
 // middleware
 const requestLogger = require('./middleware/request-logger');
@@ -43,6 +44,7 @@ app.use("/api/song", songRoutes);
 app.use("/api/startgg-import", startGgImportRoutes);
 app.use("/api/startgg", startGgPublicRoutes);
 app.use("/api/browse", browseRoutes);
+app.use("/api/seed", seedRoutes);
 
 
 app.use((req, res, next) => {

--- a/api/controllers/match.js
+++ b/api/controllers/match.js
@@ -8,6 +8,7 @@ const {
   prePopulatePlayerCache,
 } = require('../services/playerResolver');
 const { augmentStartGgSetForMatchImport } = require('../services/startGgRoundLabel');
+const { rebuildRatingsAfterMatchImport } = require('../services/ratingService');
 
 /**
  * Determines the winner(s) of a song based on scores.
@@ -1161,6 +1162,8 @@ exports.bulkImportMatches = async (req, res) => {
     summary.matchesCreated = matchRows.length;
   }
 
+  const ratingsRebuild = await rebuildRatingsAfterMatchImport('bulkImportMatches');
+
   res.status(200).json({
     message: 'Bulk import completed',
     summary: {
@@ -1171,6 +1174,7 @@ exports.bulkImportMatches = async (req, res) => {
       playersCreated: summary.playersCreated,
       errors: summary.errors.length
     },
+    ratingsRebuild: ratingsRebuild || { warning: 'Player ratings rebuild failed; use Admin Panel to refresh.' },
     errors: summary.errors.length > 0 ? summary.errors : undefined
   });
 };

--- a/api/controllers/seed.js
+++ b/api/controllers/seed.js
@@ -1,0 +1,33 @@
+const ratingService = require('../services/ratingService');
+
+exports.generateSeeding = async (req, res) => {
+  const { playerIds } = req.body || {};
+
+  if (!Array.isArray(playerIds) || playerIds.length === 0) {
+    return res.status(400).json({ message: 'playerIds must be a non-empty array.' });
+  }
+
+  try {
+    const result = await ratingService.generateSeeding(playerIds);
+    res.status(200).json(result);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    if (status >= 500) {
+      console.error('generateSeeding:', error);
+    }
+    res.status(status).json({ message: error.message || 'Failed to generate seeding.' });
+  }
+};
+
+exports.rebuildRatings = async (req, res) => {
+  try {
+    const summary = await ratingService.rebuildRatings();
+    res.status(200).json({
+      message: 'Player ratings rebuilt successfully.',
+      ...summary,
+    });
+  } catch (error) {
+    console.error('rebuildRatings:', error);
+    res.status(500).json({ message: error.message || 'Failed to rebuild player ratings.' });
+  }
+};

--- a/api/controllers/startGgImport.js
+++ b/api/controllers/startGgImport.js
@@ -16,6 +16,7 @@ const {
 } = require('../services/startGgImportQueries');
 const { resolvePlayer, prePopulatePlayerCache } = require('../services/playerResolver');
 const { importMatchesFromStartGgSets } = require('./match');
+const { rebuildRatingsAfterMatchImport } = require('../services/ratingService');
 
 const STANDINGS_PREVIEW_PER_PAGE = 25;
 const SETS_PREVIEW_PER_PAGE = 10;
@@ -174,7 +175,8 @@ async function runFullImportFromStartGgEvent(ev, slug, createdBy) {
   };
 }
 
-function sendImportSuccess(res, slug, startGgEventIdNum, summary) {
+async function sendImportSuccess(res, slug, startGgEventIdNum, summary) {
+  const ratingsRebuild = await rebuildRatingsAfterMatchImport('startGgImport');
   res.status(201).json({
     message: 'Import completed',
     slug,
@@ -188,6 +190,7 @@ function sendImportSuccess(res, slug, startGgEventIdNum, summary) {
       setsFetched: summary.setsFetched,
       matches: summary.matches,
     },
+    ratingsRebuild: ratingsRebuild || { warning: 'Player ratings rebuild failed; use Admin Panel to refresh.' },
   });
 }
 
@@ -324,7 +327,7 @@ exports.importFullStartGgEvent = async (req, res) => {
     if (result.kind === 'err') {
       return res.status(result.status).json(result.body);
     }
-    sendImportSuccess(res, result.slug, result.startGgEventIdNum, result.summary);
+    await sendImportSuccess(res, result.slug, result.startGgEventIdNum, result.summary);
   } catch (e) {
     return handleImportException(res, e, 'importFullStartGgEvent');
   }
@@ -376,7 +379,7 @@ exports.importStartGgEventById = async (req, res) => {
     if (result.kind === 'err') {
       return res.status(result.status).json(result.body);
     }
-    sendImportSuccess(
+    await sendImportSuccess(
       res,
       result.slug,
       result.startGgEventIdNum,

--- a/api/database/migrations/migration_add_player_rating.sql
+++ b/api/database/migrations/migration_add_player_rating.sql
@@ -1,0 +1,11 @@
+-- Migration: Add player_rating table for Glicko-2 ratings used by the seed generator
+
+CREATE TABLE IF NOT EXISTS `player_rating` (
+    `player_id` INT NOT NULL PRIMARY KEY,
+    `rating` DOUBLE NOT NULL DEFAULT 1500,
+    `deviation` DOUBLE NOT NULL DEFAULT 350,
+    `volatility` DOUBLE NOT NULL DEFAULT 0.06,
+    `matches_counted` INT NOT NULL DEFAULT 0,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (`player_id`) REFERENCES `player`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/api/queries/seed.js
+++ b/api/queries/seed.js
@@ -1,0 +1,92 @@
+module.exports = {
+  // Chronological 1v1 matches with a decisive winner, excluding hidden events/players.
+  GET_CHRONOLOGICAL_1V1_MATCHES: `
+    SELECT
+      m.id AS match_id,
+      m.event_id,
+      e.date AS event_date,
+      mp.player1_id,
+      mp.player2_id,
+      m.winner_id
+    FROM (
+      SELECT
+        s.match_id,
+        MIN(s.player_id) AS player1_id,
+        MAX(s.player_id) AS player2_id
+      FROM match_x_player_stats s
+      INNER JOIN \`match\` m ON m.id = s.match_id
+      INNER JOIN event e ON e.id = m.event_id AND e.hidden = 0
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM match_x_player_x_song mx
+        INNER JOIN player hp ON hp.id = mx.player_id
+        WHERE mx.match_id = s.match_id
+          AND hp.hidden_matches = 1
+      )
+      GROUP BY s.match_id
+      HAVING COUNT(DISTINCT s.player_id) = 2
+    ) mp
+    INNER JOIN \`match\` m ON m.id = mp.match_id
+    INNER JOIN event e ON e.id = m.event_id AND e.hidden = 0
+    INNER JOIN player p1 ON p1.id = mp.player1_id AND p1.hidden_matches = 0
+    INNER JOIN player p2 ON p2.id = mp.player2_id AND p2.hidden_matches = 0
+    WHERE m.winner_id IS NOT NULL
+      AND (m.winner_id = mp.player1_id OR m.winner_id = mp.player2_id)
+    ORDER BY (e.date IS NULL) ASC, e.date ASC, m.event_id ASC, m.id ASC
+  `,
+
+  DELETE_ALL_PLAYER_RATINGS: `DELETE FROM player_rating`,
+
+  GET_PLAYER_RATINGS_BY_IDS: `
+    SELECT
+      pr.player_id,
+      pr.rating,
+      pr.deviation,
+      pr.volatility,
+      pr.matches_counted,
+      p.username
+    FROM player_rating pr
+    INNER JOIN player p ON p.id = pr.player_id
+    WHERE pr.player_id IN (?)
+  `,
+
+  GET_PLAYERS_BY_IDS: `
+    SELECT id AS player_id, username
+    FROM player
+    WHERE id IN (?)
+  `,
+
+  // Head-to-head wins between two players (1v1 matches only, same visibility rules).
+  GET_HEAD_TO_HEAD_WINS: `
+    SELECT
+      m.winner_id,
+      COUNT(*) AS win_count
+    FROM (
+      SELECT
+        s.match_id,
+        MIN(s.player_id) AS player1_id,
+        MAX(s.player_id) AS player2_id
+      FROM match_x_player_stats s
+      INNER JOIN \`match\` m ON m.id = s.match_id
+      INNER JOIN event e ON e.id = m.event_id AND e.hidden = 0
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM match_x_player_x_song mx
+        INNER JOIN player hp ON hp.id = mx.player_id
+        WHERE mx.match_id = s.match_id
+          AND hp.hidden_matches = 1
+      )
+      GROUP BY s.match_id
+      HAVING COUNT(DISTINCT s.player_id) = 2
+    ) mp
+    INNER JOIN \`match\` m ON m.id = mp.match_id
+    INNER JOIN event e ON e.id = m.event_id AND e.hidden = 0
+  WHERE m.winner_id IS NOT NULL
+    AND (
+      (mp.player1_id = ? AND mp.player2_id = ?)
+      OR (mp.player1_id = ? AND mp.player2_id = ?)
+    )
+    AND (m.winner_id = mp.player1_id OR m.winner_id = mp.player2_id)
+    GROUP BY m.winner_id
+  `
+};

--- a/api/routes/seed.js
+++ b/api/routes/seed.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const seedController = require('../controllers/seed');
+const asyncWrapper = require('../middleware/async-wrapper');
+const checkAdmin = require('../middleware/check-admin');
+const router = express.Router();
+
+router.post('/generate', asyncWrapper(seedController.generateSeeding));
+router.post('/rebuild-ratings', checkAdmin, asyncWrapper(seedController.rebuildRatings));
+
+module.exports = router;

--- a/api/scripts/test-rating-service.js
+++ b/api/scripts/test-rating-service.js
@@ -1,0 +1,56 @@
+const {
+  computeRatingsFromMatches,
+  sortRosterForSeeding,
+} = require('../services/ratingService');
+const glicko2 = require('../services/glicko2');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function runTests() {
+  // Player 1 beats player 2 repeatedly; player 1 should rate higher.
+  const matches = [
+    { event_id: 1, player1_id: 1, player2_id: 2, winner_id: 1 },
+    { event_id: 1, player1_id: 1, player2_id: 2, winner_id: 1 },
+    { event_id: 2, player1_id: 1, player2_id: 2, winner_id: 1 },
+    { event_id: 2, player1_id: 1, player2_id: 3, winner_id: 1 },
+    { event_id: 3, player1_id: 2, player2_id: 3, winner_id: 2 },
+  ];
+
+  const ratings = computeRatingsFromMatches(matches);
+  const p1 = ratings.get(1);
+  const p2 = ratings.get(2);
+  const p3 = ratings.get(3);
+
+  assert(p1 && p2 && p3, 'All players should receive ratings');
+  assert(p1.rating > p2.rating, 'Winner should have higher rating than loser');
+  assert(p2.rating > p3.rating, 'Stronger player should rate above weaker player');
+  assert(p1.matchesCounted === 4, 'Player 1 should have 4 counted matches');
+  assert(glicko2.DEFAULT_RATING === 1500, 'Default rating constant');
+
+  const roster = [
+    { playerId: 1, username: 'Alice', rating: 1200, deviation: 100, matchesCounted: 20, provisional: false },
+    { playerId: 2, username: 'Bob', rating: 1800, deviation: 100, matchesCounted: 20, provisional: false },
+    { playerId: 3, username: 'Carol', rating: 1500, deviation: 100, matchesCounted: 20, provisional: false },
+  ];
+  const sorted = await sortRosterForSeeding(roster);
+  assert(sorted[0].playerId === 2, 'Highest rating should be seed 1');
+  assert(sorted[1].playerId === 3, 'Middle rating should be seed 2');
+  assert(sorted[2].playerId === 1, 'Lowest rating should be seed 3');
+
+  console.log('ratingService self-test passed');
+  console.log({
+    player1: { rating: p1.rating.toFixed(2), rd: p1.rd.toFixed(2), matches: p1.matchesCounted },
+    player2: { rating: p2.rating.toFixed(2), rd: p2.rd.toFixed(2), matches: p2.matchesCounted },
+    player3: { rating: p3.rating.toFixed(2), rd: p3.rd.toFixed(2), matches: p3.matchesCounted },
+    seedOrder: sorted.map((entry, index) => `${index + 1}. ${entry.username} (${entry.rating})`),
+  });
+}
+
+runTests().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/api/services/glicko2.js
+++ b/api/services/glicko2.js
@@ -1,0 +1,162 @@
+/**
+ * Glicko-2 rating system (Mark Glickman).
+ * @see http://www.glicko.net/glicko/glicko2.pdf
+ */
+
+const SCALE = 173.7178;
+const DEFAULT_RATING = 1500;
+const DEFAULT_RD = 350;
+const DEFAULT_VOLATILITY = 0.06;
+const TAU = 0.5;
+const EPSILON = 0.000001;
+
+function toMu(rating) {
+  return (rating - DEFAULT_RATING) / SCALE;
+}
+
+function toPhi(rd) {
+  return rd / SCALE;
+}
+
+function fromMu(mu) {
+  return mu * SCALE + DEFAULT_RATING;
+}
+
+function fromPhi(phi) {
+  return phi * SCALE;
+}
+
+function g(phi) {
+  return 1 / Math.sqrt(1 + (3 * phi * phi) / (Math.PI * Math.PI));
+}
+
+function expectedScore(mu, muJ, phiJ) {
+  return 1 / (1 + Math.exp(-g(phiJ) * (mu - muJ)));
+}
+
+function computeNewVolatility(sigma, phi, v, delta) {
+  const a = Math.log(sigma * sigma);
+  const tau2 = TAU * TAU;
+  const phi2 = phi * phi;
+  const delta2 = delta * delta;
+
+  const f = (x) => {
+    const ex = Math.exp(x);
+    const num = ex * (delta2 - phi2 - v - ex);
+    const den = 2 * (phi2 + v + ex) * (phi2 + v + ex);
+    return num / den - (x - a) / tau2;
+  };
+
+  let A = a;
+  let B;
+  if (delta2 > phi2 + v) {
+    B = Math.log(delta2 - phi2 - v);
+  } else {
+    let k = 1;
+    while (f(a - k * TAU) < 0) {
+      k += 1;
+    }
+    B = a - k * TAU;
+  }
+
+  let fA = f(A);
+  let fB = f(B);
+
+  while (Math.abs(B - A) > EPSILON) {
+    const C = A + ((A - B) * fA) / (fB - fA);
+    const fC = f(C);
+    if (fC * fB < 0) {
+      A = B;
+      fA = fB;
+    } else {
+      fA /= 2;
+    }
+    B = C;
+    fB = fC;
+  }
+
+  return Math.exp(A / 2);
+}
+
+/**
+ * @param {{ rating: number, rd: number, volatility: number }} player
+ * @param {{ mu: number, phi: number, score: number }[]} opponents
+ * @returns {{ rating: number, rd: number, volatility: number }}
+ */
+function updatePlayer(player, opponents) {
+  if (!opponents || opponents.length === 0) {
+    return player;
+  }
+
+  const mu = toMu(player.rating);
+  const phi = toPhi(player.rd);
+  const sigma = player.volatility;
+
+  let vInv = 0;
+  for (const opp of opponents) {
+    const gPhi = g(opp.phi);
+    const e = expectedScore(mu, opp.mu, opp.phi);
+    vInv += gPhi * gPhi * e * (1 - e);
+  }
+  const v = 1 / vInv;
+
+  let deltaSum = 0;
+  for (const opp of opponents) {
+    const gPhi = g(opp.phi);
+    const e = expectedScore(mu, opp.mu, opp.phi);
+    deltaSum += gPhi * (opp.score - e);
+  }
+  const delta = v * deltaSum;
+
+  const newSigma = computeNewVolatility(sigma, phi, v, delta);
+  const phiStar = Math.sqrt(phi * phi + newSigma * newSigma);
+  const newPhi = 1 / Math.sqrt(1 / (phiStar * phiStar) + 1 / v);
+
+  let muPrimeSum = 0;
+  for (const opp of opponents) {
+    const gPhi = g(opp.phi);
+    const e = expectedScore(mu, opp.mu, opp.phi);
+    muPrimeSum += gPhi * (opp.score - e);
+  }
+  const newMu = mu + newPhi * newPhi * muPrimeSum;
+
+  return {
+    rating: fromMu(newMu),
+    rd: fromPhi(newPhi),
+    volatility: newSigma,
+  };
+}
+
+/**
+ * Apply pre-period RD increase for inactivity (no matches played this period).
+ * @param {{ rating: number, rd: number, volatility: number }} player
+ */
+function applyPrePeriodRdIncrease(player) {
+  const phi = toPhi(player.rd);
+  const phiStar = Math.sqrt(phi * phi + player.volatility * player.volatility);
+  return {
+    ...player,
+    rd: fromPhi(phiStar),
+  };
+}
+
+function createDefaultPlayer() {
+  return {
+    rating: DEFAULT_RATING,
+    rd: DEFAULT_RD,
+    volatility: DEFAULT_VOLATILITY,
+    matchesCounted: 0,
+  };
+}
+
+module.exports = {
+  DEFAULT_RATING,
+  DEFAULT_RD,
+  DEFAULT_VOLATILITY,
+  SCALE,
+  toMu,
+  toPhi,
+  updatePlayer,
+  applyPrePeriodRdIncrease,
+  createDefaultPlayer,
+};

--- a/api/services/ratingService.js
+++ b/api/services/ratingService.js
@@ -1,0 +1,351 @@
+const dbconn = require('../database/connector');
+const queries = require('../queries/seed');
+const glicko2 = require('./glicko2');
+
+const PROVISIONAL_RD_THRESHOLD = 150;
+const PROVISIONAL_MATCHES_THRESHOLD = 5;
+const RATING_TIE_EPSILON = 0.5;
+const INSERT_BATCH_SIZE = 200;
+
+/**
+ * Group chronological match rows by event_id (rating period).
+ * @param {Array} rows
+ * @returns {Array<{ eventId: number, matches: Array }>}
+ */
+function groupMatchesByEvent(rows) {
+  const periods = [];
+  const periodByEvent = new Map();
+
+  for (const row of rows || []) {
+    const eventId = Number(row.event_id);
+    if (!periodByEvent.has(eventId)) {
+      const period = { eventId, matches: [] };
+      periodByEvent.set(eventId, period);
+      periods.push(period);
+    }
+    periodByEvent.get(eventId).matches.push(row);
+  }
+
+  return periods;
+}
+
+/**
+ * Replay all 1v1 matches grouped by event and compute Glicko-2 ratings.
+ * @param {Array} matchRows
+ * @returns {Map<number, { rating: number, rd: number, volatility: number, matchesCounted: number }>}
+ */
+function computeRatingsFromMatches(matchRows) {
+  const ratings = new Map();
+  const periods = groupMatchesByEvent(matchRows);
+
+  for (const period of periods) {
+    // Pre-period RD increase for all players with existing ratings.
+    for (const [playerId, state] of ratings.entries()) {
+      const updated = glicko2.applyPrePeriodRdIncrease(state);
+      ratings.set(playerId, { ...state, ...updated });
+    }
+
+    const opponentsByPlayer = new Map();
+
+    for (const match of period.matches) {
+      const player1Id = Number(match.player1_id);
+      const player2Id = Number(match.player2_id);
+      const winnerId = Number(match.winner_id);
+
+      if (!opponentsByPlayer.has(player1Id)) opponentsByPlayer.set(player1Id, []);
+      if (!opponentsByPlayer.has(player2Id)) opponentsByPlayer.set(player2Id, []);
+
+      const player1Score = winnerId === player1Id ? 1 : 0;
+      const player2Score = winnerId === player2Id ? 1 : 0;
+
+      opponentsByPlayer.get(player1Id).push({ opponentId: player2Id, score: player1Score });
+      opponentsByPlayer.get(player2Id).push({ opponentId: player1Id, score: player2Score });
+    }
+
+    if (opponentsByPlayer.size === 0) {
+      continue;
+    }
+
+    for (const playerId of opponentsByPlayer.keys()) {
+      if (!ratings.has(playerId)) {
+        ratings.set(playerId, glicko2.createDefaultPlayer());
+      }
+    }
+
+    const prePeriod = new Map();
+    for (const playerId of opponentsByPlayer.keys()) {
+      prePeriod.set(playerId, { ...ratings.get(playerId) });
+    }
+
+    for (const [playerId, opponents] of opponentsByPlayer.entries()) {
+      const current = prePeriod.get(playerId);
+      const glickoOpponents = opponents.map((opp) => {
+        const oppState = prePeriod.get(opp.opponentId) || glicko2.createDefaultPlayer();
+        return {
+          mu: glicko2.toMu(oppState.rating),
+          phi: glicko2.toPhi(oppState.rd),
+          score: opp.score,
+        };
+      });
+
+      const updated = glicko2.updatePlayer(current, glickoOpponents);
+      ratings.set(playerId, {
+        ...current,
+        ...updated,
+        matchesCounted: current.matchesCounted + opponents.length,
+      });
+    }
+  }
+
+  return ratings;
+}
+
+function isProvisional(ratingRow) {
+  return (
+    Number(ratingRow.matchesCounted || 0) < PROVISIONAL_MATCHES_THRESHOLD ||
+    Number(ratingRow.rd || ratingRow.deviation || 0) > PROVISIONAL_RD_THRESHOLD
+  );
+}
+
+async function insertRatingsBatch(connection, entries) {
+  if (!entries.length) return;
+
+  for (let i = 0; i < entries.length; i += INSERT_BATCH_SIZE) {
+    const batch = entries.slice(i, i + INSERT_BATCH_SIZE);
+    const placeholders = batch.map(() => '(?, ?, ?, ?, ?)').join(', ');
+    const params = batch.flatMap(([playerId, rating, deviation, volatility, matchesCounted]) => [
+      playerId,
+      rating,
+      deviation,
+      volatility,
+      matchesCounted,
+    ]);
+
+    await dbconn.executeMysqlQuery(
+      `INSERT INTO player_rating (player_id, rating, deviation, volatility, matches_counted) VALUES ${placeholders}`,
+      params,
+      connection
+    );
+  }
+}
+
+/**
+ * Rebuild all player ratings from 1v1 match history and persist to player_rating.
+ * @returns {Promise<{ playersRated: number, matchesProcessed: number }>}
+ */
+async function rebuildRatings() {
+  const matchRows = await dbconn.executeMysqlQuery(queries.GET_CHRONOLOGICAL_1V1_MATCHES, []);
+  const ratings = computeRatingsFromMatches(matchRows);
+  const entries = Array.from(ratings.entries()).map(([playerId, state]) => [
+    playerId,
+    Number(state.rating.toFixed(2)),
+    Number(state.rd.toFixed(2)),
+    Number(state.volatility.toFixed(6)),
+    state.matchesCounted,
+  ]);
+
+  await dbconn.withTransaction(async (connection) => {
+    await dbconn.executeMysqlQuery(queries.DELETE_ALL_PLAYER_RATINGS, [], connection);
+    await insertRatingsBatch(connection, entries);
+  });
+
+  return {
+    playersRated: entries.length,
+    matchesProcessed: (matchRows || []).length,
+  };
+}
+
+/**
+ * Compare two players for seeding tiebreaks (excluding provisional; apply that last).
+ * @returns {Promise<number>} negative if a ranks higher, positive if b ranks higher, 0 if tied
+ */
+async function comparePlayersForTiebreak(aId, bId, ratingA, ratingB) {
+  const ratingDiff = Number(ratingB.rating) - Number(ratingA.rating);
+  if (Math.abs(ratingDiff) > RATING_TIE_EPSILON) {
+    // Higher rating = better seed = sort earlier (negative return for a when a is stronger).
+    return ratingDiff > 0 ? 1 : -1;
+  }
+
+  const h2hRows = await dbconn.executeMysqlQuery(queries.GET_HEAD_TO_HEAD_WINS, [
+    aId,
+    bId,
+    bId,
+    aId,
+  ]);
+
+  let aWins = 0;
+  let bWins = 0;
+  for (const row of h2hRows || []) {
+    if (Number(row.winner_id) === aId) aWins = Number(row.win_count);
+    if (Number(row.winner_id) === bId) bWins = Number(row.win_count);
+  }
+
+  if (aWins !== bWins) {
+    return bWins - aWins;
+  }
+
+  const usernameCmp = String(ratingA.username || '').localeCompare(String(ratingB.username || ''));
+  if (usernameCmp !== 0) {
+    return usernameCmp;
+  }
+
+  return 0;
+}
+
+/**
+ * Sort roster entries best-to-worst (seed 1 first).
+ * Tiebreak chain: rating → head-to-head → username → provisional-last.
+ * @param {Array} roster
+ */
+async function sortRosterForSeeding(roster) {
+  const comparisonCache = new Map();
+  const compareKey = (aId, bId) => `${Math.min(aId, bId)}:${Math.max(aId, bId)}`;
+
+  const compareEntries = async (a, b) => {
+    const loId = Math.min(a.playerId, b.playerId);
+    const hiId = Math.max(a.playerId, b.playerId);
+    const cacheKey = compareKey(a.playerId, b.playerId);
+
+    if (!comparisonCache.has(cacheKey)) {
+      const lo = loId === a.playerId ? a : b;
+      const hi = hiId === a.playerId ? a : b;
+      let result = await comparePlayersForTiebreak(
+        lo.playerId,
+        hi.playerId,
+        { rating: lo.rating, matchesCounted: lo.matchesCounted, username: lo.username },
+        { rating: hi.rating, matchesCounted: hi.matchesCounted, username: hi.username }
+      );
+      if (result === 0 && lo.provisional !== hi.provisional) {
+        result = lo.provisional ? 1 : -1;
+      }
+      comparisonCache.set(cacheKey, result);
+    }
+
+    const stored = comparisonCache.get(cacheKey);
+    return a.playerId === loId ? stored : -stored;
+  };
+
+  const sorted = [...roster];
+  for (let i = 0; i < sorted.length; i += 1) {
+    for (let j = i + 1; j < sorted.length; j += 1) {
+      const cmp = await compareEntries(sorted[i], sorted[j]);
+      if (cmp > 0) {
+        const tmp = sorted[i];
+        sorted[i] = sorted[j];
+        sorted[j] = tmp;
+      }
+    }
+  }
+
+  return sorted;
+}
+
+/**
+ * Generate a suggested seeding for a hypothetical roster.
+ * @param {number[]} playerIds
+ */
+async function generateSeeding(playerIds) {
+  const uniqueIds = [...new Set((playerIds || []).map((id) => Number(id)).filter((id) => id > 0))];
+  if (uniqueIds.length < 2) {
+    const err = new Error('At least two distinct players are required.');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const [ratingRows, playerRows] = await Promise.all([
+    dbconn.executeMysqlQuery(queries.GET_PLAYER_RATINGS_BY_IDS, [uniqueIds]),
+    dbconn.executeMysqlQuery(queries.GET_PLAYERS_BY_IDS, [uniqueIds]),
+  ]);
+
+  const usernameById = new Map(
+    (playerRows || []).map((row) => [Number(row.player_id), row.username])
+  );
+
+  if (usernameById.size !== uniqueIds.length) {
+    const err = new Error('One or more player IDs were not found.');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const ratingById = new Map(
+    (ratingRows || []).map((row) => [
+      Number(row.player_id),
+      {
+        rating: Number(row.rating),
+        rd: Number(row.deviation),
+        volatility: Number(row.volatility),
+        matchesCounted: Number(row.matches_counted),
+        username: row.username,
+      },
+    ])
+  );
+
+  const roster = uniqueIds.map((id) => {
+    const existing = ratingById.get(id);
+    if (existing) {
+      return {
+        playerId: id,
+        username: existing.username || usernameById.get(id),
+        rating: existing.rating,
+        deviation: existing.rd,
+        matchesCounted: existing.matchesCounted,
+        provisional: isProvisional({ matchesCounted: existing.matchesCounted, rd: existing.rd }),
+      };
+    }
+
+    return {
+      playerId: id,
+      username: usernameById.get(id),
+      rating: glicko2.DEFAULT_RATING,
+      deviation: glicko2.DEFAULT_RD,
+      matchesCounted: 0,
+      provisional: true,
+    };
+  });
+
+  const sorted = await sortRosterForSeeding(roster);
+
+  const seeding = sorted.map((entry, index) => ({
+    seed: index + 1,
+    player: {
+      id: entry.playerId,
+      username: entry.username,
+    },
+    rating: Math.round(entry.rating * 100) / 100,
+    deviation: Math.round(entry.deviation * 100) / 100,
+    matchesCounted: entry.matchesCounted,
+    provisional: entry.provisional,
+  }));
+
+  return {
+    playerCount: seeding.length,
+    seeding,
+    method: 'glicko-2',
+    tiebreak: 'rating, head-to-head, username, provisional-last',
+  };
+}
+
+module.exports = {
+  rebuildRatings,
+  generateSeeding,
+  computeRatingsFromMatches,
+  isProvisional,
+  comparePlayersForTiebreak,
+  sortRosterForSeeding,
+};
+
+/**
+ * Fire-and-forget safe rebuild used after match imports.
+ * @param {string} context
+ * @returns {Promise<{ playersRated: number, matchesProcessed: number } | null>}
+ */
+module.exports.rebuildRatingsAfterMatchImport = async function rebuildRatingsAfterMatchImport(context) {
+  try {
+    const summary = await rebuildRatings();
+    console.log(`[${context}] Player ratings rebuilt:`, summary);
+    return summary;
+  } catch (error) {
+    console.error(`[${context}] Failed to rebuild player ratings:`, error);
+    return null;
+  }
+};

--- a/smx-tdb/src/app/app.component.ts
+++ b/smx-tdb/src/app/app.component.ts
@@ -36,7 +36,8 @@ export class AppComponent {
   routes: Route[] = [
     { url: "/", text: "Home", icon: "home" },
     { url: "/browse", text: "Browse", icon: "list" },
-    { url: "/compare", text: "Compare", icon: "compare_arrows" }
+    { url: "/compare", text: "Compare", icon: "compare_arrows" },
+    { url: "/seed-generator", text: "Seeds", icon: "format_list_numbered" }
   ];
   protectedRoutes: Route[] = [
     { url: '/admin-panel', text: 'Admin', icon: 'admin_panel_settings' },

--- a/smx-tdb/src/app/app.routes.ts
+++ b/smx-tdb/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { UpdatePasswordComponent } from './pages/update-password/update-password
 import { SuperAdminPanelComponent } from './pages/super-admin-panel/super-admin-panel.component';
 import { PlayerDetailComponent } from './pages/player-detail/player-detail.component';
 import { PlayerCompareComponent } from './pages/player-compare/player-compare.component';
+import { SeedGeneratorComponent } from './pages/seed-generator/seed-generator.component';
 import { EventDetailComponent } from './pages/event-detail/event-detail.component';
 import { MatchDetailComponent } from './pages/match-detail/match-detail.component';
 import { AuthGuard } from './shared/auth/auth-guard';
@@ -14,6 +15,7 @@ export const routes: Routes = [
   { path: '', component: HomeComponent, data: { title: 'Home' } },
   { path: 'browse', component: BrowseComponent, data: { title: 'Browse' } },
   { path: 'compare', component: PlayerCompareComponent, data: { title: 'Compare Players' } },
+  { path: 'seed-generator', component: SeedGeneratorComponent, data: { title: 'Seed Generator' } },
   { path: 'player/:id', component: PlayerDetailComponent, data: { title: 'Player' } },
   { path: 'event/:id', component: EventDetailComponent, data: { title: 'Event' } },
   { path: 'match/:id', component: MatchDetailComponent, data: { title: 'Match' } },

--- a/smx-tdb/src/app/models/seed.ts
+++ b/smx-tdb/src/app/models/seed.ts
@@ -1,0 +1,26 @@
+export interface SeedPlayerResult {
+  id: number;
+  username: string;
+}
+
+export interface SeedEntry {
+  seed: number;
+  player: SeedPlayerResult;
+  rating: number;
+  deviation: number;
+  matchesCounted: number;
+  provisional: boolean;
+}
+
+export interface SeedGenerateResponse {
+  playerCount: number;
+  seeding: SeedEntry[];
+  method: string;
+  tiebreak: string;
+}
+
+export interface RebuildRatingsResponse {
+  message: string;
+  playersRated: number;
+  matchesProcessed: number;
+}

--- a/smx-tdb/src/app/pages/admin-panel/admin-panel.component.html
+++ b/smx-tdb/src/app/pages/admin-panel/admin-panel.component.html
@@ -41,6 +41,14 @@
           <app-start-gg-stepmania-discovery></app-start-gg-stepmania-discovery>
         </app-form-wrapper>
       </mat-tab>
+      <mat-tab label="Player Ratings">
+        <app-form-wrapper>
+          <div form-title>
+            <h2>Player Ratings</h2>
+          </div>
+          <app-player-ratings-refresh></app-player-ratings-refresh>
+        </app-form-wrapper>
+      </mat-tab>
       <mat-tab label="Privacy / Match Data">
         <app-form-wrapper>
           <div form-title>

--- a/smx-tdb/src/app/pages/admin-panel/admin-panel.component.ts
+++ b/smx-tdb/src/app/pages/admin-panel/admin-panel.component.ts
@@ -7,10 +7,11 @@ import { FormWrapperComponent } from './form-wrapper/form-wrapper.component';
 import { StartGgImportComponent } from './start-gg-import/start-gg-import.component';
 import { StartGgStepmaniaDiscoveryComponent } from './start-gg-stepmania-discovery/start-gg-stepmania-discovery.component';
 import { PlayerMatchPrivacyComponent } from './player-match-privacy/player-match-privacy.component';
+import { PlayerRatingsRefreshComponent } from './player-ratings-refresh/player-ratings-refresh.component';
 
 @Component({
   selector: 'app-admin-panel',
-  imports: [SharedModule, EventListComponent, EventUsersListComponent, EventMatchesListComponent, FormWrapperComponent, StartGgImportComponent, StartGgStepmaniaDiscoveryComponent, PlayerMatchPrivacyComponent],
+  imports: [SharedModule, EventListComponent, EventUsersListComponent, EventMatchesListComponent, FormWrapperComponent, StartGgImportComponent, StartGgStepmaniaDiscoveryComponent, PlayerMatchPrivacyComponent, PlayerRatingsRefreshComponent],
   templateUrl: './admin-panel.component.html',
   styleUrl: './admin-panel.component.scss'
 })

--- a/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.html
+++ b/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.html
@@ -1,0 +1,20 @@
+<div class="ratings-refresh">
+  <p>
+    Rebuild Glicko-2 ratings from all 1v1 match history. Ratings are refreshed automatically after match imports;
+    use this after manually adding or editing matches in the admin panel.
+  </p>
+
+  <button
+    mat-raised-button
+    color="primary"
+    type="button"
+    [disabled]="isRefreshing"
+    (click)="refreshRatings()"
+  >
+    <mat-spinner *ngIf="isRefreshing" diameter="20" class="inline-spinner"></mat-spinner>
+    <span *ngIf="!isRefreshing">Refresh player ratings</span>
+    <span *ngIf="isRefreshing">Refreshing…</span>
+  </button>
+
+  <p *ngIf="lastSummary" class="summary">{{ lastSummary }}</p>
+</div>

--- a/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.scss
+++ b/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.scss
@@ -1,0 +1,17 @@
+.ratings-refresh {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.summary {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.inline-spinner {
+  display: inline-block;
+  margin-right: 8px;
+  vertical-align: middle;
+}

--- a/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.ts
+++ b/smx-tdb/src/app/pages/admin-panel/player-ratings-refresh/player-ratings-refresh.component.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { SeedService } from '../../../services/seed.service';
+import { MessageService } from '../../../services/message.service';
+import { SharedModule } from '../../../shared/shared.module';
+import { RebuildRatingsResponse } from '../../../models/seed';
+
+@Component({
+  selector: 'app-player-ratings-refresh',
+  standalone: true,
+  imports: [CommonModule, SharedModule],
+  templateUrl: './player-ratings-refresh.component.html',
+  styleUrl: './player-ratings-refresh.component.scss',
+})
+export class PlayerRatingsRefreshComponent {
+  isRefreshing = false;
+  lastSummary: string | null = null;
+
+  constructor(
+    private seedService: SeedService,
+    private messageService: MessageService
+  ) {}
+
+  refreshRatings(): void {
+    if (this.isRefreshing) {
+      return;
+    }
+
+    this.isRefreshing = true;
+    this.lastSummary = null;
+
+    this.seedService.rebuildRatings().subscribe({
+      next: (response: RebuildRatingsResponse) => {
+        this.isRefreshing = false;
+        this.lastSummary = `${response.playersRated} players rated from ${response.matchesProcessed} 1v1 matches.`;
+        this.messageService.show(response.message || 'Player ratings refreshed.');
+      },
+      error: (err: { error?: { message?: string } }) => {
+        this.isRefreshing = false;
+        const message = err?.error?.message || 'Failed to refresh player ratings.';
+        this.messageService.show(message);
+      },
+    });
+  }
+}

--- a/smx-tdb/src/app/pages/home/home.component.html
+++ b/smx-tdb/src/app/pages/home/home.component.html
@@ -134,7 +134,20 @@
 
   <div *ngIf="!hasSearched && !isLoading" class="welcome-section">
     <h2>StepManiaX Tournament DB</h2>
-    <p>Use the search bar above to find players, events, or matches, or <a routerLink="/browse" class="link">browse</a> all available data.</p>
+    <p class="welcome-intro">
+      Use the search bar above to find players, events, or matches, or
+      <a routerLink="/browse" class="link">browse</a> all available data.
+    </p>
+    <ul class="welcome-features">
+      <li>
+        <a routerLink="/compare" class="link">Compare players</a>
+        <span class="welcome-feature-desc">— Pick two competitors and view head-to-head match and song records.</span>
+      </li>
+      <li>
+        <a routerLink="/seed-generator" class="link">Seed generator</a>
+        <span class="welcome-feature-desc">— Build a hypothetical roster and get a suggested seeding from Glicko-2 ratings.</span>
+      </li>
+    </ul>
   </div>
 
   <div class="top5-section">

--- a/smx-tdb/src/app/pages/home/home.component.scss
+++ b/smx-tdb/src/app/pages/home/home.component.scss
@@ -345,20 +345,42 @@
     color: rgba(255, 255, 255, 0.95);
   }
 
-  p {
+  .welcome-intro {
     font-size: 1.1rem;
-    margin: 0;
+    margin: 0 0 1.25rem;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .welcome-features {
+    list-style: none;
+    margin: 0 auto;
+    padding: 0;
+    max-width: 640px;
+    text-align: left;
+  }
+
+  .welcome-features li {
+    font-size: 1.05rem;
+    line-height: 1.5;
     color: rgba(255, 255, 255, 0.8);
 
-    .link {
-      color: rgba(255, 255, 255, 0.9);
-      text-decoration: underline;
-      cursor: pointer;
-      transition: color 0.2s ease;
+    & + li {
+      margin-top: 0.75rem;
+    }
+  }
 
-      &:hover {
-        color: rgba(255, 255, 255, 1);
-      }
+  .welcome-feature-desc {
+    color: rgba(255, 255, 255, 0.72);
+  }
+
+  .link {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: underline;
+    cursor: pointer;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: rgba(255, 255, 255, 1);
     }
   }
 }

--- a/smx-tdb/src/app/pages/seed-generator/seed-generator.component.html
+++ b/smx-tdb/src/app/pages/seed-generator/seed-generator.component.html
@@ -1,0 +1,106 @@
+<div class="seed-container">
+  <app-back-to-search></app-back-to-search>
+
+  <div class="header-section">
+    <mat-icon class="header-icon">format_list_numbered</mat-icon>
+    <div class="header-main">
+      <h1>Seed generator</h1>
+      <p class="header-subtitle">
+        Build a hypothetical roster and get a suggested seeding from Glicko-2 ratings based on 1v1 match history.
+        <button
+          mat-icon-button
+          type="button"
+          class="help-button"
+          matTooltip="How are ratings calculated?"
+          aria-label="How are ratings calculated?"
+          (click)="openRatingsHelp()"
+        >
+          <mat-icon>help_outline</mat-icon>
+        </button>
+      </p>
+    </div>
+  </div>
+
+  <mat-card class="seed-card">
+    <mat-card-content>
+      <mat-form-field appearance="outline" class="player-field">
+        <mat-label>Add player</mat-label>
+        <input
+          matInput
+          [formControl]="playerControl"
+          [matAutocomplete]="playerAuto"
+          placeholder="Type at least 2 letters"
+        />
+        <mat-icon matPrefix>person_add</mat-icon>
+        <mat-autocomplete
+          #playerAuto="matAutocomplete"
+          [displayWith]="displayPlayer"
+          (optionSelected)="onSelectPlayer($event.option.value)"
+        >
+          <mat-option *ngFor="let player of (playerSuggestions$ | async)" [value]="player">
+            <span>{{ player.username }}</span>
+            <span *ngIf="player.pronouns" class="muted"> ({{ player.pronouns }})</span>
+          </mat-option>
+        </mat-autocomplete>
+      </mat-form-field>
+
+      <div *ngIf="roster.length" class="roster-section">
+        <div class="roster-header">
+          <h2>Roster ({{ roster.length }})</h2>
+          <button mat-button type="button" (click)="clearRoster()">Clear roster</button>
+        </div>
+        <mat-chip-set class="roster-chips">
+          <mat-chip *ngFor="let player of roster" (removed)="removePlayer(player.id!)">
+            {{ player.username }}
+            <button matChipRemove [attr.aria-label]="'Remove ' + player.username">
+              <mat-icon>cancel</mat-icon>
+            </button>
+          </mat-chip>
+        </mat-chip-set>
+      </div>
+
+      <div class="actions-row">
+        <button mat-raised-button color="primary" type="button" [disabled]="!canGenerate()" (click)="generateSeeding()">
+          Generate seeding
+        </button>
+      </div>
+
+      <div *ngIf="error" class="error-row">
+        <mat-icon class="error-icon">error</mat-icon>
+        <span>{{ error }}</span>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <div *ngIf="isGenerating" class="loading-section">
+    <mat-spinner diameter="40"></mat-spinner>
+    <p>Generating seeding…</p>
+  </div>
+
+  <mat-card *ngIf="seeding.length" class="results-card">
+    <mat-card-title>Suggested seeding</mat-card-title>
+    <mat-card-subtitle *ngIf="method">
+      Method: {{ method }} · Tiebreak: {{ tiebreak }}
+    </mat-card-subtitle>
+    <mat-card-content>
+      <div class="results-actions">
+        <button mat-stroked-button type="button" (click)="copySeeding()">Copy list</button>
+        <button mat-stroked-button type="button" (click)="exportSeedingToCsv()">Export to CSV</button>
+      </div>
+      <div class="seeding-list">
+        <div *ngFor="let entry of seeding" class="seeding-row">
+          <span class="seed-number">{{ entry.seed }}</span>
+          <div class="player-block">
+            <a class="player-link" [routerLink]="['/player', entry.player.id]">{{ entry.player.username }}</a>
+            <span *ngIf="entry.provisional" class="provisional-badge">Provisional</span>
+          </div>
+          <div class="rating-block">
+            <span class="rating-value">{{ entry.rating }}</span>
+            <span class="muted">RD {{ entry.deviation }}</span>
+            <span class="muted">{{ entry.matchesCounted }} 1v1 matches</span>
+          </div>
+        </div>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/smx-tdb/src/app/pages/seed-generator/seed-generator.component.scss
+++ b/smx-tdb/src/app/pages/seed-generator/seed-generator.component.scss
@@ -1,0 +1,185 @@
+.seed-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.header-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 12px 0 16px;
+}
+
+.header-icon {
+  font-size: 40px;
+  width: 40px;
+  height: 40px;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.header-main h1 {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.2;
+}
+
+.header-subtitle {
+  margin: 8px 0 0;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.help-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin: -2px 0 0 2px;
+  color: rgba(255, 255, 255, 0.72);
+  --mat-icon-button-state-layer-size: 24px;
+  --mat-icon-button-touch-target-display: none;
+
+  .mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    line-height: 18px;
+  }
+}
+
+.seed-card,
+.results-card {
+  margin-bottom: 16px;
+}
+
+.player-field {
+  width: 100%;
+}
+
+.roster-section {
+  margin-top: 8px;
+}
+
+.roster-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.roster-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.roster-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actions-row {
+  margin-top: 16px;
+}
+
+.error-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  color: #ff8a80;
+}
+
+.loading-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.results-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.seeding-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.seeding-row {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.seed-number {
+  font-size: 22px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.player-block {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.player-link {
+  color: #90caf9;
+  text-decoration: none;
+}
+
+.player-link:hover {
+  text-decoration: underline;
+}
+
+.provisional-badge {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 193, 7, 0.2);
+  color: #ffd54f;
+}
+
+.rating-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-align: right;
+}
+
+.rating-value {
+  font-weight: 600;
+}
+
+.muted {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 13px;
+}
+
+@media (max-width: 640px) {
+  .seeding-row {
+    grid-template-columns: 40px 1fr;
+  }
+
+  .rating-block {
+    grid-column: 2;
+    align-items: flex-start;
+    text-align: left;
+  }
+}

--- a/smx-tdb/src/app/pages/seed-generator/seed-generator.component.ts
+++ b/smx-tdb/src/app/pages/seed-generator/seed-generator.component.ts
@@ -1,0 +1,197 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
+import { Player } from '../../models/player';
+import { SeedEntry } from '../../models/seed';
+import { PlayerService } from '../../services/player.service';
+import { SeedService } from '../../services/seed.service';
+import { SharedModule } from '../../shared/shared.module';
+import { SeedRatingsHelpDialogComponent } from './seed-ratings-help-dialog/seed-ratings-help-dialog.component';
+
+@Component({
+  selector: 'app-seed-generator',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, SharedModule],
+  templateUrl: './seed-generator.component.html',
+  styleUrl: './seed-generator.component.scss',
+})
+export class SeedGeneratorComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
+  playerControl = new FormControl<Player | string>('');
+  playerSuggestions$: Observable<Player[]>;
+
+  roster: Player[] = [];
+  seeding: SeedEntry[] = [];
+  method = '';
+  tiebreak = '';
+
+  isGenerating = false;
+  error: string | null = null;
+
+  constructor(
+    private playerService: PlayerService,
+    private seedService: SeedService,
+    private dialog: MatDialog
+  ) {
+    this.playerSuggestions$ = this.playerControl.valueChanges.pipe(
+      startWith(''),
+      debounceTime(250),
+      map((value) => this.textFromPlayerControl(value)),
+      distinctUntilChanged(),
+      switchMap((query) => {
+        if (query.trim().length < 2) {
+          return of([]);
+        }
+        return this.playerService.searchPlayers(query).pipe(catchError(() => of([])));
+      })
+    );
+  }
+
+  displayPlayer(player: Player | string | null): string {
+    if (!player) {
+      return '';
+    }
+    if (typeof player === 'string') {
+      return player;
+    }
+    return player.username || '';
+  }
+
+  onSelectPlayer(player: Player): void {
+    if (!player?.id) {
+      return;
+    }
+    if (this.roster.some((entry) => entry.id === player.id)) {
+      this.error = `${player.username} is already on the roster.`;
+      this.playerControl.setValue('');
+      return;
+    }
+
+    this.roster = [...this.roster, player];
+    this.playerControl.setValue('');
+    this.error = null;
+    this.seeding = [];
+  }
+
+  removePlayer(playerId: number): void {
+    this.roster = this.roster.filter((player) => player.id !== playerId);
+    this.seeding = [];
+  }
+
+  clearRoster(): void {
+    this.roster = [];
+    this.seeding = [];
+    this.error = null;
+  }
+
+  generateSeeding(): void {
+    if (this.roster.length < 2) {
+      this.error = 'Add at least two players to generate a seeding.';
+      return;
+    }
+
+    const playerIds = this.roster
+      .map((player) => player.id)
+      .filter((id): id is number => typeof id === 'number');
+
+    this.isGenerating = true;
+    this.error = null;
+
+    this.seedService
+      .generateSeeding(playerIds)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          this.seeding = response.seeding || [];
+          this.method = response.method;
+          this.tiebreak = response.tiebreak;
+          this.isGenerating = false;
+        },
+        error: (err) => {
+          this.error = err?.error?.message || 'Failed to generate seeding.';
+          this.isGenerating = false;
+        },
+      });
+  }
+
+  copySeeding(): void {
+    if (!this.seeding.length) {
+      return;
+    }
+
+    const lines = this.seeding.map(
+      (entry) =>
+        `${entry.seed}. ${entry.player.username} (rating ${entry.rating}${entry.provisional ? ', provisional' : ''})`
+    );
+    navigator.clipboard.writeText(lines.join('\n')).catch(() => {
+      this.error = 'Could not copy to clipboard.';
+    });
+  }
+
+  exportSeedingToCsv(): void {
+    if (!this.seeding.length) {
+      return;
+    }
+
+    const headers = ['Seed', 'Player ID', 'Username', 'Rating', 'RD', '1v1 Matches', 'Provisional'];
+    const rows = this.seeding.map((entry) => [
+      entry.seed,
+      entry.player.id,
+      entry.player.username,
+      entry.rating,
+      entry.deviation,
+      entry.matchesCounted,
+      entry.provisional ? 'Yes' : 'No',
+    ]);
+
+    const csv = [headers, ...rows].map((row) => row.map((cell) => this.escapeCsvCell(cell)).join(',')).join('\r\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `seed-generator-${this.buildExportTimestamp()}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  canGenerate(): boolean {
+    return this.roster.length >= 2 && !this.isGenerating;
+  }
+
+  openRatingsHelp(): void {
+    this.dialog.open(SeedRatingsHelpDialogComponent, {
+      width: '560px',
+      autoFocus: false,
+    });
+  }
+
+  private textFromPlayerControl(value: Player | string | null): string {
+    if (!value) {
+      return '';
+    }
+    if (typeof value === 'string') {
+      return value;
+    }
+    return value.username || '';
+  }
+
+  private escapeCsvCell(value: string | number): string {
+    const text = String(value);
+    if (/[",\r\n]/.test(text)) {
+      return `"${text.replace(/"/g, '""')}"`;
+    }
+    return text;
+  }
+
+  private buildExportTimestamp(): string {
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+  }
+}

--- a/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.html
+++ b/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.html
@@ -1,0 +1,41 @@
+<h2 mat-dialog-title>How ratings are calculated</h2>
+<mat-dialog-content>
+  <p>
+    Suggested seedings use precomputed <strong>Glicko-2</strong> ratings derived from match history in this database.
+    Each player gets a rating (strength estimate), an RD (rating deviation, a confidence measure), and a count of
+    matches used.
+  </p>
+
+  <h3>What matches count</h3>
+  <ul>
+    <li>Only strictly <strong>1v1</strong> matches with a recorded winner are included.</li>
+    <li>Matches with three or more players are skipped.</li>
+  </ul>
+
+  <h3>How Glicko-2 ratings are built</h3>
+  <ul>
+    <li>All eligible 1v1 matches are replayed in chronological order, grouped by event.</li>
+    <li>Each event acts as a rating period: results within that event update player ratings together.</li>
+    <li>Beating a stronger opponent raises your rating more; losing to a weaker opponent lowers it more.</li>
+    <li>Ratings are stored in the database and rebuilt after match imports.</li>
+  </ul>
+
+  <h3>How seeding is ordered</h3>
+  <p>When you generate a seeding for your roster, players are sorted best-to-worst using this tiebreak chain:</p>
+  <ol>
+    <li><strong>Glicko-2 rating</strong> (higher = better seed)</li>
+    <li><strong>Head-to-head</strong> record among the selected players</li>
+    <li><strong>Username</strong> (alphabetical)</li>
+    <li><strong>Provisional-last</strong> if still tied</li>
+  </ol>
+
+  <h3>Provisional ratings</h3>
+  <p>
+    A player is marked <strong>Provisional</strong> when they have fewer than 5 counted 1v1 matches or their RD is
+    above 150, meaning the rating is still uncertain. Players without any rating history start at the default rating
+    of 1500 and are also provisional.
+  </p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="close()">Close</button>
+</mat-dialog-actions>

--- a/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.scss
+++ b/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.scss
@@ -1,0 +1,27 @@
+mat-dialog-content {
+  max-width: 520px;
+  line-height: 1.5;
+}
+
+mat-dialog-content h3 {
+  margin: 20px 0 8px;
+  font-size: 16px;
+}
+
+mat-dialog-content h3:first-of-type {
+  margin-top: 0;
+}
+
+mat-dialog-content p {
+  margin: 0 0 12px;
+}
+
+mat-dialog-content ul,
+mat-dialog-content ol {
+  margin: 0 0 12px;
+  padding-left: 20px;
+}
+
+mat-dialog-content li + li {
+  margin-top: 4px;
+}

--- a/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.ts
+++ b/smx-tdb/src/app/pages/seed-generator/seed-ratings-help-dialog/seed-ratings-help-dialog.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-seed-ratings-help-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
+  templateUrl: './seed-ratings-help-dialog.component.html',
+  styleUrl: './seed-ratings-help-dialog.component.scss',
+})
+export class SeedRatingsHelpDialogComponent {
+  constructor(public dialogRef: MatDialogRef<SeedRatingsHelpDialogComponent>) {}
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/smx-tdb/src/app/services/seed.service.ts
+++ b/smx-tdb/src/app/services/seed.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { RebuildRatingsResponse, SeedGenerateResponse } from '../models/seed';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SeedService {
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService
+  ) {}
+
+  generateSeeding(playerIds: number[]): Observable<SeedGenerateResponse> {
+    return this.http.post<SeedGenerateResponse>(`${environment.apiUrl}/seed/generate`, {
+      playerIds,
+    });
+  }
+
+  rebuildRatings(): Observable<RebuildRatingsResponse> {
+    const token = this.authService.getToken();
+    return this.http.post<RebuildRatingsResponse>(
+      `${environment.apiUrl}/seed/rebuild-ratings`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds a tournament seed generator powered by Glicko-2 player ratings derived from 1v1 match history.

**Backend**
- Adds `player_rating` table and migration for storing Glicko-2 rating, RD, volatility, and matches counted
- Implements Glicko-2 rating computation (`glicko2.js`, `ratingService.js`) by replaying chronological 1v1 matches grouped by event
- New seed API: `POST /seed/generate` (roster → suggested seeding) and `POST /seed/rebuild-ratings` (admin-only full rebuild)
- Automatically rebuilds ratings after bulk match import and start.gg event import

**Frontend**
- New Seed Generator page: build a hypothetical roster, generate seeding, view ratings/provisional status, and copy results
- Help dialog explaining how ratings and tiebreaks work
- Admin panel control to manually refresh player ratings
- Home page and nav updated to surface Compare and Seed Generator

**Seeding logic**
- Sort by Glicko-2 rating; tiebreaks: head-to-head → username → provisional players last
- Players without rating history get default provisional values

Also adds a PR template and a Cursor skill for drafting PR descriptions.

## Test plan

- [ ] Run `migration_add_player_rating.sql` on the database
- [ ] Refresh player ratings from Admin Panel and confirm counts look reasonable
- [ ] Seed Generator: add players, generate seeding, verify order and provisional flags
- [ ] Import matches (bulk or start.gg) and confirm ratings rebuild in the response
- [ ] Confirm `/seed/rebuild-ratings` requires admin auth