### PR TITLE
53 mobile styling fix

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -2,7 +2,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
-dotenv.config();
+dotenv.config({override: true});
 
 // external routing files
 const userRoutes = require('./routes/user');

--- a/api/app.js
+++ b/api/app.js
@@ -2,7 +2,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
-dotenv.config({override: true});
+dotenv.config();
 
 // external routing files
 const userRoutes = require('./routes/user');

--- a/api/controllers/browse.js
+++ b/api/controllers/browse.js
@@ -17,9 +17,17 @@ function mapTopPlayersRows(rows) {
 }
 
 function mapLeaderboardRows(rows) {
-  return mapTopPlayersRows(rows).map((row, index) => ({
-    rank: index + 1,
-    ...row,
+  return (rows || []).map((r) => ({
+    rank: Number(r.leaderboard_rank),
+    id: r.player_id,
+    username: r.username,
+    rating: Number(r.rating),
+    deviation: Number(r.deviation),
+    matchesCounted: Number(r.matches_counted || 0),
+    provisional: ratingService.isProvisional({
+      matchesCounted: r.matches_counted,
+      deviation: r.deviation,
+    }),
   }));
 }
 
@@ -62,8 +70,10 @@ exports.getLeaderboard = async (req, res) => {
   const rawQuery = String(req.query.q || '').trim();
   const searchTerm = rawQuery ? `%${rawQuery}%` : '';
 
+  const includeProvisionalFlag = includeProvisional ? 1 : 0;
   const rows = await dbconn.executeMysqlQuery(queries.GET_LEADERBOARD_PLAYERS_BY_RATING, [
-    includeProvisional ? 1 : 0,
+    includeProvisionalFlag,
+    includeProvisionalFlag,
     searchTerm,
     searchTerm,
   ]);

--- a/api/queries/browse.js
+++ b/api/queries/browse.js
@@ -62,7 +62,18 @@ module.exports = {
       p.username,
       pr.rating,
       pr.deviation,
-      pr.matches_counted
+      pr.matches_counted,
+      (
+        SELECT COUNT(*) + 1
+        FROM player_rating pr2
+        INNER JOIN player p2 ON p2.id = pr2.player_id
+        WHERE p2.hidden_matches = 0
+          AND (? = 1 OR (pr2.matches_counted >= 5 AND pr2.deviation <= 150))
+          AND (
+            pr2.rating > pr.rating OR
+            (pr2.rating = pr.rating AND p2.username < p.username)
+          )
+      ) AS leaderboard_rank
     FROM player_rating pr
     INNER JOIN player p ON p.id = pr.player_id
     WHERE p.hidden_matches = 0

--- a/smx-tdb/src/app/app.component.scss
+++ b/smx-tdb/src/app/app.component.scss
@@ -1,12 +1,10 @@
 .app-container {
   display: grid;
-  grid-template-rows: auto 1fr; // Toolbar takes its natural height, content fills the rest
-  height: 100vh;
-  width: 100vw;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  height: 100dvh;
+  width: 100%;
   overflow: hidden;
-  position: fixed;
-  top: 0;
-  left: 0;
 }
 
 .app-toolbar {
@@ -94,12 +92,14 @@
 .mat-sidenav-container {
   grid-row: 2;
   height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
 // Material sidenav-content must fill its container
 ::ng-deep .mat-sidenav-content {
   height: 100% !important;
+  min-height: 0 !important;
   display: flex !important;
   flex-direction: column !important;
   overflow: hidden !important;
@@ -111,6 +111,9 @@
   overflow-y: auto;
   overflow-x: hidden;
   width: 100%;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
   
   * :not(.material-icons) {
     font-family: "Titillium Web", "Arial", "Times New Roman", "serif" !important;
@@ -143,8 +146,9 @@ h1 {
   position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  height: 100dvh;
+  width: 100%;
   background-color: rgba(0,0,0,0.5);
   display: flex;
   justify-content: center;

--- a/smx-tdb/src/app/pages/home/home.component.html
+++ b/smx-tdb/src/app/pages/home/home.component.html
@@ -144,6 +144,10 @@
         <span class="welcome-feature-desc">&nbsp;— Pick two competitors and view head-to-head match records.</span>
       </li>
       <li>
+        <a routerLink="/leaderboard" class="link">Leaderboard</a>
+        <span class="welcome-feature-desc">&nbsp;— Browse all rated players by Glicko-2 rating, with optional provisional ratings and search.</span>
+      </li>
+      <li>
         <a routerLink="/seed-generator" class="link">Seed generator</a>
         <span class="welcome-feature-desc">&nbsp;— Build a hypothetical roster and get a suggested seeding from Glicko-2 ratings.</span>
       </li>

--- a/smx-tdb/src/app/pages/leaderboard/leaderboard.component.html
+++ b/smx-tdb/src/app/pages/leaderboard/leaderboard.component.html
@@ -62,7 +62,7 @@
         <p>No rated players found{{ filterControl.value ? ' matching your filter' : '' }}.</p>
       </div>
 
-      <mat-list *ngIf="!isLoading && !error && players.length > 0">
+      <mat-list class="leaderboard-list" *ngIf="!isLoading && !error && players.length > 0">
         <mat-list-item *ngFor="let player of players">
           <div class="leaderboard-row">
             <span class="leaderboard-rank">#{{ player.rank }}</span>

--- a/smx-tdb/src/app/pages/leaderboard/leaderboard.component.scss
+++ b/smx-tdb/src/app/pages/leaderboard/leaderboard.component.scss
@@ -59,6 +59,23 @@
   margin-bottom: 1rem;
 }
 
+.leaderboard-list {
+  ::ng-deep mat-list-item {
+    height: auto !important;
+    min-height: 48px;
+    padding-block: 8px;
+
+    .mdc-list-item__content,
+    .mat-mdc-list-item-content,
+    .mat-mdc-list-item-unscoped-content {
+      overflow: visible !important;
+      align-items: flex-start;
+      height: auto !important;
+      white-space: normal;
+    }
+  }
+}
+
 .leaderboard-row {
   display: flex;
   flex-wrap: wrap;
@@ -68,15 +85,18 @@
 }
 
 .leaderboard-rank {
-  min-width: 3rem;
+  min-width: 2.5rem;
   font-weight: 700;
+  flex-shrink: 0;
 }
 
 .leaderboard-link {
-  min-width: 10rem;
+  min-width: 0;
+  flex: 1 1 8rem;
   color: inherit;
   text-decoration: none;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .leaderboard-link:hover {
@@ -90,4 +110,36 @@
   gap: 0.75rem;
   align-items: center;
   padding: 1rem 0;
+}
+
+@media (max-width: 600px) {
+  .leaderboard-container {
+    padding: 0.75rem 0.5rem;
+  }
+
+  .leaderboard-row {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.5rem;
+    row-gap: 0.35rem;
+    align-items: center;
+  }
+
+  .leaderboard-rank {
+    min-width: 0;
+  }
+
+  app-player-rating-summary {
+    grid-column: 1 / -1;
+  }
+
+  app-player-rating-summary ::ng-deep .rating-summary__label {
+    display: none;
+  }
+
+  app-player-rating-summary ::ng-deep .rating-summary__item:not(:last-child)::after {
+    content: '·';
+    margin-left: 0.35rem;
+    color: rgba(255, 255, 255, 0.45);
+  }
 }

--- a/smx-tdb/src/app/pages/player-detail/player-detail.component.scss
+++ b/smx-tdb/src/app/pages/player-detail/player-detail.component.scss
@@ -2,8 +2,6 @@
   max-width: 1000px;
   margin: 0 auto;
   padding: 2rem 1rem;
-  overflow-y: auto;
-  min-height: 100%;
 }
 
 .back-button {

--- a/smx-tdb/src/index.html
+++ b/smx-tdb/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>SmxTdb</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/smx-tdb/src/styles.scss
+++ b/smx-tdb/src/styles.scss
@@ -1,7 +1,20 @@
 /* You can add global styles to this file, and also import other style files */
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+html, body {
+  height: 100%;
+  height: 100dvh;
+  margin: 0;
+  overflow: hidden;
+}
+
+app-root {
+  display: block;
+  height: 100%;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+body { font-family: Roboto, "Helvetica Neue", sans-serif; }
 .mat-sidenav {
   width: 250px;
 }


### PR DESCRIPTION
## Summary
Fixes mobile layout and scrolling issues across the app, and corrects leaderboard rank display when filtering or searching.

## Mobile styling

- Replaces 100vh/100vw and position: fixed with 100dvh and a flex/grid layout so content scrolls correctly on mobile browsers (especially iOS).
- Adds viewport-fit=cover, safe-area padding, touch scrolling, and overscroll-behavior on the main content area.
- Removes nested scrolling on the player detail page.
- Improves leaderboard layout on narrow screens: grid layout, wrapping usernames, and a compact rating summary.
## Leaderboard filtering

- Computes leaderboard_rank in SQL so ranks reflect global position, not just the filtered result set.
- Updates the API mapper to use server-provided ranks instead of re-numbering filtered rows client-side.
## Other

- Adds a Leaderboard link on the home page welcome section.
- Closes #53 (if applicable).