### PR TITLE
feat: merge players for handle changes

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -2,7 +2,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
-dotenv.config();
+dotenv.config({ override: true });
 
 // external routing files
 const userRoutes = require('./routes/user');

--- a/api/controllers/player.js
+++ b/api/controllers/player.js
@@ -1,6 +1,8 @@
 const dbconn = require('../database/connector');
 const queries = require('../queries/player');
 const ratingService = require('../services/ratingService');
+const playerMergeService = require('../services/playerMergeService');
+const { PlayerMergeError } = playerMergeService;
 
 async function fetchMatchIdsByPlayerId(playerId) {
   const rows = await dbconn.executeMysqlQuery(
@@ -158,6 +160,48 @@ exports.updatePlayer = async (req, res) => {
   await dbconn.executeMysqlQuery(queries.UPDATE_PLAYER, [gamertag || player[0].username, pronouns !== undefined ? pronouns : player[0].pronouns, user_id !== undefined ? user_id : player[0].created_by, playerId]);
   const updatedPlayer = await dbconn.executeMysqlQuery(queries.GET_PLAYER_BY_ID, [playerId]);
   res.status(200).json(updatedPlayer[0]);
+};
+
+/**
+ * Admin: preview merging Absorb into Keep (event histories + overlap check).
+ * Query: keepId, absorbId
+ */
+exports.previewPlayerMerge = async (req, res) => {
+  try {
+    const preview = await playerMergeService.previewMerge(req.query.keepId, req.query.absorbId);
+    res.status(200).json(preview);
+  } catch (error) {
+    if (error instanceof PlayerMergeError) {
+      return res.status(error.statusCode).json({ message: error.message });
+    }
+    throw error;
+  }
+};
+
+/**
+ * Admin: merge Absorb player history into Keep, delete Absorb, rebuild ratings.
+ * Body: { keepId, absorbId, username? }
+ */
+exports.mergePlayers = async (req, res) => {
+  try {
+    const result = await playerMergeService.mergePlayers({
+      keepId: req.body?.keepId,
+      absorbId: req.body?.absorbId,
+      username: req.body?.username,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    if (error instanceof PlayerMergeError) {
+      return res.status(error.statusCode).json({ message: error.message });
+    }
+    // Unique-key collisions from unexpected shared-match data
+    if (error && (error.code === 'ER_DUP_ENTRY' || error.errno === 1062)) {
+      return res.status(409).json({
+        message: 'Cannot merge: remapping would create duplicate match or rating rows.',
+      });
+    }
+    throw error;
+  }
 };
 
 /**

--- a/api/queries/player.js
+++ b/api/queries/player.js
@@ -37,11 +37,26 @@ module.exports = {
     WHERE p.id = ?
   `,
   GET_PLAYER_BY_USERNAME: `SELECT * FROM player WHERE username = ?`,
+  GET_PLAYER_BASIC_BY_ID: `SELECT * FROM player WHERE id = ?`,
   SEARCH_PLAYERS: `SELECT * FROM player WHERE username LIKE ? ORDER BY username ASC LIMIT 50`,
   CREATE_PLAYER: `INSERT INTO player (username, pronouns, created_by) VALUES (?, ?, ?)`,
   UPDATE_PLAYER: `UPDATE player SET username = ?, pronouns = ?, created_by = ? WHERE id = ?`,
+  UPDATE_PLAYER_USERNAME: `UPDATE player SET username = ? WHERE id = ?`,
   UPDATE_PLAYER_HIDDEN_MATCHES: `UPDATE player SET hidden_matches = ? WHERE id = ?`,
   DELETE_PLAYER: `DELETE FROM player WHERE id = ?`,
+  // Includes hidden events so merge overlap checks see full attendance history.
+  GET_ALL_EVENTS_BY_PLAYER: `SELECT DISTINCT e.*, ep.placement, ep.seed
+    FROM event_x_player ep
+    INNER JOIN event e ON ep.event_id = e.id
+    WHERE ep.player_id = ?
+    ORDER BY e.date DESC`,
+  GET_OVERLAPPING_EVENT_IDS: `
+    SELECT DISTINCT a.event_id
+    FROM event_x_player a
+    INNER JOIN event_x_player b ON a.event_id = b.event_id
+    WHERE a.player_id = ? AND b.player_id = ?
+    ORDER BY a.event_id ASC
+  `,
   // NOTE: Alias ids to avoid `id` collisions between `event_x_player` and `player`.
   // Frontend expects both the join-row id (event_player_id) and the player id (player_id).
   GET_PLAYERS_BY_EVENT: `

--- a/api/routes/player.js
+++ b/api/routes/player.js
@@ -10,6 +10,9 @@ router.get("/ratings", asyncWrapper(playerController.getRatingsByIds));
 router.get("/search", asyncWrapper(playerController.searchPlayers));
 router.get("/gamertag/:gamertag", asyncWrapper(playerController.getPlayerByGamertag));
 router.get("/event/:eventId", asyncWrapper(playerController.getPlayersByEvent));
+// Admin merge routes must be registered before /:id
+router.get("/merge/preview", checkAdmin, asyncWrapper(playerController.previewPlayerMerge));
+router.post("/merge", checkAdmin, asyncWrapper(playerController.mergePlayers));
 router.get("/:id/events", asyncWrapper(playerController.getEventsByPlayer));
 router.get("/:id/rivals", asyncWrapper(playerController.getRivalsForPlayer));
 router.get("/:id", asyncWrapper(playerController.getPlayerById));

--- a/api/services/playerMergeService.js
+++ b/api/services/playerMergeService.js
@@ -1,0 +1,214 @@
+const dbconn = require('../database/connector');
+const queries = require('../queries/player');
+const ratingService = require('./ratingService');
+
+class PlayerMergeError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = 'PlayerMergeError';
+    this.statusCode = statusCode;
+  }
+}
+
+function parsePlayerId(value) {
+  const id = Number(value);
+  if (!Number.isFinite(id) || id <= 0 || !Number.isInteger(id)) {
+    return null;
+  }
+  return id;
+}
+
+async function getPlayerRow(playerId, connection) {
+  const rows = await dbconn.executeMysqlQuery(
+    queries.GET_PLAYER_BASIC_BY_ID,
+    [playerId],
+    connection
+  );
+  return rows && rows.length > 0 ? rows[0] : null;
+}
+
+async function getEventsForPlayer(playerId, connection) {
+  return dbconn.executeMysqlQuery(
+    queries.GET_ALL_EVENTS_BY_PLAYER,
+    [playerId],
+    connection
+  );
+}
+
+async function getOverlappingEventIds(keepId, absorbId, connection) {
+  const rows = await dbconn.executeMysqlQuery(
+    queries.GET_OVERLAPPING_EVENT_IDS,
+    [keepId, absorbId],
+    connection
+  );
+  return (rows || []).map((row) => Number(row.event_id));
+}
+
+/**
+ * Load both players, their event histories, and overlap status for admin preview.
+ * @param {number|string} keepId
+ * @param {number|string} absorbId
+ */
+async function previewMerge(keepId, absorbId) {
+  const keepPlayerId = parsePlayerId(keepId);
+  const absorbPlayerId = parsePlayerId(absorbId);
+
+  if (!keepPlayerId || !absorbPlayerId) {
+    throw new PlayerMergeError('keepId and absorbId must be positive integers.');
+  }
+  if (keepPlayerId === absorbPlayerId) {
+    throw new PlayerMergeError('Keep and Absorb players must be different.');
+  }
+
+  const [keep, absorb] = await Promise.all([
+    getPlayerRow(keepPlayerId),
+    getPlayerRow(absorbPlayerId),
+  ]);
+
+  if (!keep) {
+    throw new PlayerMergeError('Keep player not found.', 404);
+  }
+  if (!absorb) {
+    throw new PlayerMergeError('Absorb player not found.', 404);
+  }
+
+  const [keepEvents, absorbEvents, overlappingEventIds] = await Promise.all([
+    getEventsForPlayer(keepPlayerId),
+    getEventsForPlayer(absorbPlayerId),
+    getOverlappingEventIds(keepPlayerId, absorbPlayerId),
+  ]);
+
+  return {
+    keep,
+    absorb,
+    keepEvents: keepEvents || [],
+    absorbEvents: absorbEvents || [],
+    overlappingEventIds,
+    canMerge: overlappingEventIds.length === 0,
+  };
+}
+
+/**
+ * Remap Absorb history onto Keep, optionally rename Keep, delete Absorb, rebuild ratings.
+ * @param {{ keepId: number|string, absorbId: number|string, username?: string }} params
+ */
+async function mergePlayers({ keepId, absorbId, username }) {
+  const keepPlayerId = parsePlayerId(keepId);
+  const absorbPlayerId = parsePlayerId(absorbId);
+
+  if (!keepPlayerId || !absorbPlayerId) {
+    throw new PlayerMergeError('keepId and absorbId must be positive integers.');
+  }
+  if (keepPlayerId === absorbPlayerId) {
+    throw new PlayerMergeError('Keep and Absorb players must be different.');
+  }
+
+  const desiredUsername =
+    username !== undefined && username !== null
+      ? String(username).trim()
+      : null;
+
+  if (desiredUsername !== null && (desiredUsername.length < 1 || desiredUsername.length > 50)) {
+    throw new PlayerMergeError('Username must be between 1 and 50 characters.');
+  }
+
+  const mergeResult = await dbconn.withTransaction(async (connection) => {
+    const keep = await getPlayerRow(keepPlayerId, connection);
+    const absorb = await getPlayerRow(absorbPlayerId, connection);
+
+    if (!keep) {
+      throw new PlayerMergeError('Keep player not found.', 404);
+    }
+    if (!absorb) {
+      throw new PlayerMergeError('Absorb player not found.', 404);
+    }
+
+    const overlappingEventIds = await getOverlappingEventIds(
+      keepPlayerId,
+      absorbPlayerId,
+      connection
+    );
+    if (overlappingEventIds.length > 0) {
+      throw new PlayerMergeError(
+        `Cannot merge: players share ${overlappingEventIds.length} event(s).`
+      );
+    }
+
+    if (desiredUsername !== null && desiredUsername !== keep.username) {
+      const existing = await dbconn.executeMysqlQuery(
+        queries.GET_PLAYER_BY_USERNAME,
+        [desiredUsername],
+        connection
+      );
+      const conflict = (existing || []).find(
+        (row) => Number(row.id) !== keepPlayerId && Number(row.id) !== absorbPlayerId
+      );
+      if (conflict) {
+        throw new PlayerMergeError(
+          `Username "${desiredUsername}" is already used by another player.`
+        );
+      }
+    }
+
+    // Remap foreign keys from Absorb → Keep before deleting Absorb.
+    await dbconn.executeMysqlQuery(
+      'UPDATE event_x_player SET player_id = ? WHERE player_id = ?',
+      [keepPlayerId, absorbPlayerId],
+      connection
+    );
+    await dbconn.executeMysqlQuery(
+      'UPDATE `match` SET winner_id = ? WHERE winner_id = ?',
+      [keepPlayerId, absorbPlayerId],
+      connection
+    );
+    await dbconn.executeMysqlQuery(
+      'UPDATE match_x_player_x_song SET player_id = ? WHERE player_id = ?',
+      [keepPlayerId, absorbPlayerId],
+      connection
+    );
+    await dbconn.executeMysqlQuery(
+      'UPDATE match_x_player_stats SET player_id = ? WHERE player_id = ?',
+      [keepPlayerId, absorbPlayerId],
+      connection
+    );
+    await dbconn.executeMysqlQuery(
+      'UPDATE match_player_rating SET player_id = ? WHERE player_id = ?',
+      [keepPlayerId, absorbPlayerId],
+      connection
+    );
+
+    if (desiredUsername !== null && desiredUsername !== keep.username) {
+      await dbconn.executeMysqlQuery(
+        queries.UPDATE_PLAYER_USERNAME,
+        [desiredUsername, keepPlayerId],
+        connection
+      );
+    }
+
+    await dbconn.executeMysqlQuery(
+      queries.DELETE_PLAYER,
+      [absorbPlayerId],
+      connection
+    );
+
+    const survivor = await getPlayerRow(keepPlayerId, connection);
+    return {
+      player: survivor,
+      absorbedPlayerId: absorbPlayerId,
+      absorbedUsername: absorb.username,
+    };
+  });
+
+  const ratingsRebuild = await ratingService.rebuildRatingsAfterMatchImport('playerMerge');
+
+  return {
+    ...mergeResult,
+    ratingsRebuild,
+  };
+}
+
+module.exports = {
+  PlayerMergeError,
+  previewMerge,
+  mergePlayers,
+};

--- a/smx-tdb/src/app/pages/admin-panel/admin-panel.component.html
+++ b/smx-tdb/src/app/pages/admin-panel/admin-panel.component.html
@@ -57,6 +57,14 @@
           <app-player-match-privacy></app-player-match-privacy>
         </app-form-wrapper>
       </mat-tab>
+      <mat-tab label="Merge Players">
+        <app-form-wrapper>
+          <div form-title>
+            <h2>Merge Players</h2>
+          </div>
+          <app-player-merge></app-player-merge>
+        </app-form-wrapper>
+      </mat-tab>
     </mat-tab-group>
   </mat-card>
 </div>

--- a/smx-tdb/src/app/pages/admin-panel/admin-panel.component.ts
+++ b/smx-tdb/src/app/pages/admin-panel/admin-panel.component.ts
@@ -8,10 +8,11 @@ import { StartGgImportComponent } from './start-gg-import/start-gg-import.compon
 import { StartGgStepmaniaDiscoveryComponent } from './start-gg-stepmania-discovery/start-gg-stepmania-discovery.component';
 import { PlayerMatchPrivacyComponent } from './player-match-privacy/player-match-privacy.component';
 import { PlayerRatingsRefreshComponent } from './player-ratings-refresh/player-ratings-refresh.component';
+import { PlayerMergeComponent } from './player-merge/player-merge.component';
 
 @Component({
   selector: 'app-admin-panel',
-  imports: [SharedModule, EventListComponent, EventUsersListComponent, EventMatchesListComponent, FormWrapperComponent, StartGgImportComponent, StartGgStepmaniaDiscoveryComponent, PlayerMatchPrivacyComponent, PlayerRatingsRefreshComponent],
+  imports: [SharedModule, EventListComponent, EventUsersListComponent, EventMatchesListComponent, FormWrapperComponent, StartGgImportComponent, StartGgStepmaniaDiscoveryComponent, PlayerMatchPrivacyComponent, PlayerRatingsRefreshComponent, PlayerMergeComponent],
   templateUrl: './admin-panel.component.html',
   styleUrl: './admin-panel.component.scss'
 })

--- a/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.html
+++ b/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.html
@@ -1,0 +1,138 @@
+<div class="player-merge">
+  <h3>Merge Player Histories</h3>
+  <p class="muted">
+    Move one player’s event and match history onto another when they never attended the same event
+    (e.g. a handle change). The Absorb player is deleted; ratings rebuild automatically.
+  </p>
+
+  <div class="selectors">
+    <div class="selector-column">
+      <h4>Keep (survives)</h4>
+
+      <mat-form-field appearance="outline" class="search-field" *ngIf="!keepPlayer">
+        <mat-label>Search keep player</mat-label>
+        <input matInput [formControl]="keepSearchControl" placeholder="Type a gamertag" />
+        <mat-icon matPrefix>search</mat-icon>
+        <button *ngIf="keepSearchControl.value" matSuffix mat-icon-button type="button"
+          (click)="keepSearchControl.setValue('')" aria-label="Clear keep search">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+
+      <div *ngIf="isSearchingKeep" class="muted">Searching…</div>
+
+      <mat-list *ngIf="!keepPlayer && keepResults.length > 0" class="results">
+        <mat-list-item *ngFor="let p of keepResults" (click)="selectKeep(p)" class="clickable">
+          <div class="row">
+            <span class="name">{{ p.username }}</span>
+            <span class="muted">ID {{ p.id || p.player_id }}</span>
+          </div>
+        </mat-list-item>
+      </mat-list>
+
+      <div *ngIf="keepPlayer" class="selected-card">
+        <div class="selected-header">
+          <div>
+            <div class="selected-title">Keep player</div>
+            <div class="selected-name">{{ keepPlayer.username }}</div>
+            <div class="muted">ID {{ keepPlayer.id || keepPlayer.player_id }}</div>
+          </div>
+          <button mat-stroked-button type="button" (click)="clearKeep()">Change</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="selector-column">
+      <h4>Absorb (deleted)</h4>
+
+      <mat-form-field appearance="outline" class="search-field" *ngIf="!absorbPlayer">
+        <mat-label>Search absorb player</mat-label>
+        <input matInput [formControl]="absorbSearchControl" placeholder="Type a gamertag" />
+        <mat-icon matPrefix>search</mat-icon>
+        <button *ngIf="absorbSearchControl.value" matSuffix mat-icon-button type="button"
+          (click)="absorbSearchControl.setValue('')" aria-label="Clear absorb search">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
+
+      <div *ngIf="isSearchingAbsorb" class="muted">Searching…</div>
+
+      <mat-list *ngIf="!absorbPlayer && absorbResults.length > 0" class="results">
+        <mat-list-item *ngFor="let p of absorbResults" (click)="selectAbsorb(p)" class="clickable">
+          <div class="row">
+            <span class="name">{{ p.username }}</span>
+            <span class="muted">ID {{ p.id || p.player_id }}</span>
+          </div>
+        </mat-list-item>
+      </mat-list>
+
+      <div *ngIf="absorbPlayer" class="selected-card">
+        <div class="selected-header">
+          <div>
+            <div class="selected-title">Absorb player</div>
+            <div class="selected-name">{{ absorbPlayer.username }}</div>
+            <div class="muted">ID {{ absorbPlayer.id || absorbPlayer.player_id }}</div>
+          </div>
+          <button mat-stroked-button type="button" (click)="clearAbsorb()">Change</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div *ngIf="isLoadingPreview" class="muted">Loading preview…</div>
+
+  <div *ngIf="preview" class="preview">
+    <div class="overlap" *ngIf="!preview.canMerge">
+      Cannot merge: these players share
+      {{ preview.overlappingEventIds.length }}
+      event{{ preview.overlappingEventIds.length === 1 ? '' : 's' }}.
+    </div>
+    <div class="ok" *ngIf="preview.canMerge">
+      No overlapping events — merge is allowed.
+    </div>
+
+    <div class="event-columns">
+      <div class="event-list">
+        <h4>Keep events ({{ preview.keepEvents.length }})</h4>
+        <ul *ngIf="preview.keepEvents.length > 0; else noKeepEvents">
+          <li *ngFor="let e of preview.keepEvents"
+            [class.overlap-event]="preview.overlappingEventIds.includes(e.id!)">
+            <span class="event-name">{{ e.name }}</span>
+            <span class="muted">{{ formatEventDate(e) }}</span>
+            <span class="muted" *ngIf="e.placement != null">Place {{ e.placement }}</span>
+            <span class="hidden-tag" *ngIf="e.hidden">Hidden</span>
+          </li>
+        </ul>
+        <ng-template #noKeepEvents><p class="muted">No events</p></ng-template>
+      </div>
+
+      <div class="event-list">
+        <h4>Absorb events ({{ preview.absorbEvents.length }})</h4>
+        <ul *ngIf="preview.absorbEvents.length > 0; else noAbsorbEvents">
+          <li *ngFor="let e of preview.absorbEvents"
+            [class.overlap-event]="preview.overlappingEventIds.includes(e.id!)">
+            <span class="event-name">{{ e.name }}</span>
+            <span class="muted">{{ formatEventDate(e) }}</span>
+            <span class="muted" *ngIf="e.placement != null">Place {{ e.placement }}</span>
+            <span class="hidden-tag" *ngIf="e.hidden">Hidden</span>
+          </li>
+        </ul>
+        <ng-template #noAbsorbEvents><p class="muted">No events</p></ng-template>
+      </div>
+    </div>
+
+    <mat-form-field appearance="outline" class="search-field" *ngIf="preview.canMerge">
+      <mat-label>Resulting username</mat-label>
+      <input matInput [formControl]="usernameControl" placeholder="Username for surviving player" />
+    </mat-form-field>
+
+    <button
+      mat-raised-button
+      color="warn"
+      type="button"
+      (click)="confirmMerge()"
+      [disabled]="!preview.canMerge || isMerging || !usernameControl.value.trim()">
+      {{ isMerging ? 'Merging…' : 'Merge Players' }}
+    </button>
+  </div>
+</div>

--- a/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.scss
+++ b/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.scss
@@ -1,0 +1,136 @@
+.player-merge {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.selectors {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .selectors {
+    grid-template-columns: 1fr;
+  }
+}
+
+.selector-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.search-field {
+  width: 100%;
+  max-width: 520px;
+}
+
+.results {
+  max-width: 520px;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+}
+
+.name {
+  font-weight: 600;
+}
+
+.muted {
+  opacity: 0.8;
+  font-size: 12px;
+}
+
+.selected-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 520px;
+}
+
+.selected-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.selected-title {
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+.selected-name {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 960px;
+}
+
+.overlap {
+  color: #b71c1c;
+  font-weight: 600;
+}
+
+.ok {
+  color: #1b5e20;
+  font-weight: 600;
+}
+
+.event-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .event-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.event-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.event-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 13px;
+}
+
+.event-name {
+  font-weight: 600;
+}
+
+.overlap-event {
+  color: #b71c1c;
+}
+
+.hidden-tag {
+  font-size: 11px;
+  opacity: 0.75;
+  text-transform: uppercase;
+}

--- a/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.ts
+++ b/smx-tdb/src/app/pages/admin-panel/player-merge/player-merge.component.ts
@@ -1,0 +1,223 @@
+import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { SharedModule } from '../../../shared/shared.module';
+import { PlayerService, PlayerMergePreview } from '../../../services/player.service';
+import { Player } from '../../../models/player';
+import { Event } from '../../../models/event';
+import { MessageService } from '../../../services/message.service';
+import { ConfirmationDialogComponent } from '../../../shared/components/confirmation-dialog/confirmation-dialog.component';
+
+@Component({
+  selector: 'app-player-merge',
+  standalone: true,
+  imports: [SharedModule, ReactiveFormsModule],
+  templateUrl: './player-merge.component.html',
+  styleUrl: './player-merge.component.scss'
+})
+export class PlayerMergeComponent {
+  keepSearchControl = new FormControl('');
+  absorbSearchControl = new FormControl('');
+  usernameControl = new FormControl('', { nonNullable: true });
+
+  keepResults: Player[] = [];
+  absorbResults: Player[] = [];
+  keepPlayer: Player | null = null;
+  absorbPlayer: Player | null = null;
+
+  preview: PlayerMergePreview | null = null;
+  isSearchingKeep = false;
+  isSearchingAbsorb = false;
+  isLoadingPreview = false;
+  isMerging = false;
+
+  constructor(
+    private playerService: PlayerService,
+    private messageService: MessageService,
+    private dialog: MatDialog
+  ) {
+    this.keepSearchControl.valueChanges
+      .pipe(
+        debounceTime(250),
+        distinctUntilChanged(),
+        switchMap((value) => {
+          const q = (value || '').trim();
+          if (!q || this.keepPlayer) {
+            this.keepResults = [];
+            return of([]);
+          }
+          this.isSearchingKeep = true;
+          return this.playerService.searchPlayers(q);
+        })
+      )
+      .subscribe({
+        next: (players) => {
+          this.keepResults = players || [];
+          this.isSearchingKeep = false;
+        },
+        error: () => {
+          this.keepResults = [];
+          this.isSearchingKeep = false;
+        }
+      });
+
+    this.absorbSearchControl.valueChanges
+      .pipe(
+        debounceTime(250),
+        distinctUntilChanged(),
+        switchMap((value) => {
+          const q = (value || '').trim();
+          if (!q || this.absorbPlayer) {
+            this.absorbResults = [];
+            return of([]);
+          }
+          this.isSearchingAbsorb = true;
+          return this.playerService.searchPlayers(q);
+        })
+      )
+      .subscribe({
+        next: (players) => {
+          this.absorbResults = players || [];
+          this.isSearchingAbsorb = false;
+        },
+        error: () => {
+          this.absorbResults = [];
+          this.isSearchingAbsorb = false;
+        }
+      });
+  }
+
+  selectKeep(player: Player): void {
+    this.keepPlayer = player;
+    this.keepResults = [];
+    this.keepSearchControl.setValue(player.username, { emitEvent: false });
+    this.usernameControl.setValue(player.username || '');
+    this.loadPreview();
+  }
+
+  selectAbsorb(player: Player): void {
+    this.absorbPlayer = player;
+    this.absorbResults = [];
+    this.absorbSearchControl.setValue(player.username, { emitEvent: false });
+    this.loadPreview();
+  }
+
+  clearKeep(): void {
+    this.keepPlayer = null;
+    this.keepResults = [];
+    this.keepSearchControl.setValue('');
+    this.usernameControl.setValue('');
+    this.preview = null;
+  }
+
+  clearAbsorb(): void {
+    this.absorbPlayer = null;
+    this.absorbResults = [];
+    this.absorbSearchControl.setValue('');
+    this.preview = null;
+  }
+
+  private playerId(player: Player | null): number | null {
+    const id = player?.id ?? player?.player_id;
+    return id != null ? Number(id) : null;
+  }
+
+  private loadPreview(): void {
+    const keepId = this.playerId(this.keepPlayer);
+    const absorbId = this.playerId(this.absorbPlayer);
+    if (!keepId || !absorbId) {
+      this.preview = null;
+      return;
+    }
+    if (keepId === absorbId) {
+      this.preview = null;
+      this.messageService.show('Keep and Absorb must be different players.');
+      return;
+    }
+
+    this.isLoadingPreview = true;
+    this.playerService.previewPlayerMerge(keepId, absorbId).subscribe({
+      next: (preview) => {
+        this.preview = preview;
+        this.isLoadingPreview = false;
+        if (!this.usernameControl.value && preview.keep?.username) {
+          this.usernameControl.setValue(preview.keep.username);
+        }
+      },
+      error: (err) => {
+        console.error('Error loading merge preview:', err);
+        this.preview = null;
+        this.isLoadingPreview = false;
+        const msg = err?.error?.message || 'Error loading merge preview.';
+        this.messageService.show(msg);
+      }
+    });
+  }
+
+  formatEventDate(event: Event): string {
+    if (!event?.date) return '';
+    const d = new Date(event.date);
+    if (Number.isNaN(d.getTime())) return String(event.date);
+    return d.toLocaleDateString();
+  }
+
+  confirmMerge(): void {
+    const keepId = this.playerId(this.keepPlayer);
+    const absorbId = this.playerId(this.absorbPlayer);
+    if (!keepId || !absorbId || !this.preview?.canMerge || this.isMerging) {
+      return;
+    }
+
+    const keepName = this.keepPlayer?.username || `ID ${keepId}`;
+    const absorbName = this.absorbPlayer?.username || `ID ${absorbId}`;
+    const resultingUsername = this.usernameControl.value.trim() || keepName;
+
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      width: '480px',
+      data: {
+        title: 'Merge Players',
+        message:
+          `Merge "${absorbName}" into "${keepName}"? ` +
+          `All event and match history from "${absorbName}" will move to "${keepName}" (ID ${keepId}), ` +
+          `"${absorbName}" will be deleted, and the surviving username will be "${resultingUsername}". ` +
+          `Ratings will be rebuilt. This cannot be undone.`,
+        confirmText: 'Merge',
+        cancelText: 'Cancel'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe((confirmed) => {
+      if (!confirmed) return;
+      this.runMerge(keepId, absorbId, resultingUsername);
+    });
+  }
+
+  private runMerge(keepId: number, absorbId: number, username: string): void {
+    this.isMerging = true;
+    this.playerService.mergePlayers(keepId, absorbId, username).subscribe({
+      next: (result) => {
+        this.isMerging = false;
+        const rebuild = result.ratingsRebuild;
+        const rebuildMsg = rebuild
+          ? ` Ratings rebuilt (${rebuild.playersRated} players).`
+          : ' Ratings rebuild failed; use Player Ratings to rebuild manually.';
+        this.messageService.show(
+          `Merged "${result.absorbedUsername}" into "${result.player.username}".${rebuildMsg}`
+        );
+        this.clearAbsorb();
+        this.keepPlayer = result.player;
+        this.keepSearchControl.setValue(result.player.username || '', { emitEvent: false });
+        this.usernameControl.setValue(result.player.username || '');
+        this.preview = null;
+      },
+      error: (err) => {
+        console.error('Error merging players:', err);
+        this.isMerging = false;
+        const msg = err?.error?.message || 'Error merging players. Please try again.';
+        this.messageService.show(msg);
+      }
+    });
+  }
+}

--- a/smx-tdb/src/app/services/player.service.ts
+++ b/smx-tdb/src/app/services/player.service.ts
@@ -13,6 +13,22 @@ export interface PlayerRatingResponse extends PlayerRatingSummary {
   username: string;
 }
 
+export interface PlayerMergePreview {
+  keep: Player;
+  absorb: Player;
+  keepEvents: Event[];
+  absorbEvents: Event[];
+  overlappingEventIds: number[];
+  canMerge: boolean;
+}
+
+export interface PlayerMergeResult {
+  player: Player;
+  absorbedPlayerId: number;
+  absorbedUsername: string;
+  ratingsRebuild: { playersRated: number; matchesProcessed: number } | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -118,6 +134,38 @@ export class PlayerService {
         }
       }
     );
+  }
+
+  /** Admin-only: preview merging Absorb into Keep. */
+  previewPlayerMerge(keepId: number, absorbId: number): Observable<PlayerMergePreview> {
+    const token = this.authService.getToken();
+    const params = new HttpParams()
+      .set('keepId', String(keepId))
+      .set('absorbId', String(absorbId));
+    return this.http.get<PlayerMergePreview>(`${environment.apiUrl}/player/merge/preview`, {
+      params,
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+  }
+
+  /** Admin-only: merge Absorb into Keep, delete Absorb, rebuild ratings. */
+  mergePlayers(
+    keepId: number,
+    absorbId: number,
+    username?: string
+  ): Observable<PlayerMergeResult> {
+    const token = this.authService.getToken();
+    const body: { keepId: number; absorbId: number; username?: string } = { keepId, absorbId };
+    if (username !== undefined) {
+      body.username = username;
+    }
+    return this.http.post<PlayerMergeResult>(`${environment.apiUrl}/player/merge`, body, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an admin **Merge Players** flow so duplicate player records (e.g. after a handle change) can be combined safely.

- New admin-only APIs: `GET /player/merge/preview` and `POST /player/merge` (Keep vs Absorb).
- Preview loads both players’ event histories (including hidden events) and blocks merge when they share any event.
- Merge remaps Absorb history onto Keep (`event_x_player`, matches, song scores, stats, ratings), optionally renames Keep, deletes Absorb, then rebuilds ratings.
- New Admin Panel tab with player search, side-by-side event lists, overlap highlighting, confirmation dialog, and username override.

## Test plan

- [ ] Tested locally
- [ ] As admin, open Admin Panel → Merge Players; search and select Keep and Absorb players
- [ ] Confirm preview shows both event lists and disables merge when players share an event
- [ ] Merge two non-overlapping players; verify Absorb is deleted, history appears under Keep, and ratings rebuild
- [ ] Optionally rename Keep during merge; confirm username conflict with a third player is rejected
- [ ] Confirm non-admin requests to merge endpoints are rejected